### PR TITLE
fix: 修复在debain系统上bat不可用问题

### DIFF
--- a/zsh/.env/base.sh
+++ b/zsh/.env/base.sh
@@ -1,9 +1,9 @@
 export PATH=$PATH:~/.local/bin
 export EDITOR=nvim
 
-export http_proxy=http://127.0.0.1:7890
-export https_proxy=$http_proxy
-export no_proxy="localhost,127.0.0.1,localaddress,.localdomain.com"
+# export http_proxy=http://127.0.0.1:7890
+# export https_proxy=$http_proxy
+# export no_proxy="localhost,127.0.0.1,localaddress,.localdomain.com"
 
 # need neovim package
 if [ -x "/usr/bin/nvim" ]; then
@@ -21,6 +21,11 @@ fi
 # need bat package
 if [ -x "/usr/bin/bat" ]; then
     alias cat="bat"
+fi
+
+# if debian need batcat
+if [ -x "/usr/bin/batcat" ]; then
+    alias cat="batcat"
 fi
 
 # need rsync package


### PR DESCRIPTION
debian上bat的名称为batcat，所以添加一个或判断

Log: